### PR TITLE
Correct syntax error on code snippet in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ The following properties are required:
 
 To determine if a package is valid, use the `pkg.valid` getter method:
 
-``js
+```js
 pkg.valid
 // => false
 ```


### PR DESCRIPTION
A code snippet was just missing a backtick. 
