### PR TITLE
'use strict'

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+'use strict'
 const revalidator = require('revalidator')
 const schema = require('./lib/schema')
 const clean = require('./lib/clean')


### PR DESCRIPTION
```
module.exports = class Package {
                 ^^^^^
SyntaxError: Block-scoped declarations (let, const, function, class) not yet supported outside strict mode
```

@zeke ^
