### PR TITLE
allow source metadata to be sparse

### DIFF
--- a/lib/clean.js
+++ b/lib/clean.js
@@ -9,11 +9,16 @@ module.exports = function clean (doc) {
   var pkg
 
   if (doc['dist-tags'] && doc['dist-tags']) {
+    // registry object
     doc = normalize(doc)
     var latest = doc['dist-tags'].latest
     pkg = doc.versions[latest]
   } else if (doc.name && doc.description) {
+    // regular old package.json object
     pkg = doc
+  } else {
+    // incomplete package.json object
+    return doc
   }
 
   try {

--- a/tests/fixtures/sparse.json
+++ b/tests/fixtures/sparse.json
@@ -1,0 +1,9 @@
+{
+  "about": "not much here in this package.json. missing name, description, etc",
+  "dependencies": {
+    "request": "^2.65.0"
+  },
+  "devDependencies": {
+    "chai": "^3.3.0"
+  }
+}

--- a/tests/index.js
+++ b/tests/index.js
@@ -46,16 +46,6 @@ test('Package', function (t) {
   t.ok(pkg.mentions('minimalist web framework'), '`mentions` looks for a string anywhere in the object')
   t.ok(pkg.mentions('MINIMALIST WEB FRAMEWORK'), '`mentions` is case insensitive')
 
-  t.comment('reusing clean packages')
-  var repkg = new Package(pkg)
-  t.ok(repkg.name, 'packages can be reconstituted from an already-cleaned package object')
-
-  t.comment('creating with package.json data instead of registry data')
-  var packageJSONPackage = new Package(fixtures.spectron)
-  t.equal(packageJSONPackage.name, 'spectron', 'packages can be constituted from package.json data')
-  t.ok(packageJSONPackage.dependsOn('webdriverio'), 'and the convenience methods still work')
-  t.ok(packageJSONPackage.devDependsOn('mocha'), 'and the convenience methods still work')
-
   t.comment('validation')
   t.ok(pkg.valid, 'package is valid if required properties are present')
 
@@ -71,5 +61,20 @@ test('Package', function (t) {
   t.equal(pkg.validationErrors[0].property, 'name', '`name` error is present')
   pkg.name = 'express'
 
+  t.comment('reusing clean packages')
+  var repkg = new Package(pkg)
+  t.ok(repkg.name, 'packages can be reconstituted from an already-cleaned package object')
+
+  t.comment('using package.json data instead of registry data')
+  var packageJSONPackage = new Package(fixtures.spectron)
+  t.equal(packageJSONPackage.name, 'spectron', 'packages can be constituted from package.json data')
+  t.ok(packageJSONPackage.dependsOn('webdriverio'), 'and the convenience methods still work')
+  t.ok(packageJSONPackage.devDependsOn('mocha'), 'and the convenience methods still work')
+
+  t.comment('using incomplete package.json data')
+  var sparsePackage = new Package(fixtures.sparse)
+  t.notOk(sparsePackage.name, 'does not have a name')
+  t.notOk(sparsePackage.valid, 'is not valid')
+  t.ok(sparsePackage.dependsOn('request'), 'still has working convenience methods')
   t.end()
 })


### PR DESCRIPTION
When creating nice packages from package.json files in GitHub repos, sometimes the package.json  only has the bare minimum, i.e. no `name`, no `description`, etc. This PR allows any object to be used. It may not end up being a "valid" nice package, but it will at least not blow up, and will allow methods like `dependsOn` to still be used.
