### PR TITLE
New convenience methods, standard markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ call `new Package(doc)`, where `doc` is a JSON package object from the npm regis
 const got = require('got')
 const Package = require('nice-package')
 
-got('https://registry.npmjs.com/express', {json:true})
-  .then(function(doc) {
+got('https://registry.npmjs.com/express', {json: true})
+  .then(function (doc) {
     var pkg = new Package(doc)
     console.log(JSON.stringify(pkg, null, 2))
   })

--- a/README.md
+++ b/README.md
@@ -81,6 +81,13 @@ Returns a Boolean indicating whether the given `pkgName` is listed in `dependenc
 
 Returns a Boolean indicating whether the given `pkgName` is listed in `devDependencies`.
 
+#### `pkg.somehowDependsOn(pkgName)`
+
+* `pkgName` String - The name of another package
+
+Returns a Boolean indicating whether the given `pkgName` is listed in
+`dependencies` or `devDependencies`.
+
 #### `pkg.depNames`
 
 A getter method that returns an array of the `dependencies` keys.
@@ -88,6 +95,11 @@ A getter method that returns an array of the `dependencies` keys.
 #### `pkg.devDepNames`
 
 A getter method that returns an array of the `devDependencies` keys.
+
+#### `pkg.allDepNames`
+
+A getter method that returns an array of all the `dependencies` and
+`devDependencies` keys.
 
 ## Validation
 

--- a/index.js
+++ b/index.js
@@ -23,12 +23,20 @@ module.exports = class Package {
     return this.devDepNames.indexOf(dep) > -1
   }
 
+  dependsSomehowOn (dep) {
+    return this.dependsOn(dep) || this.devDependsOn(dep)
+  }
+
   get depNames () {
-    return this.dependencies ? Object.keys(this.dependencies) : []
+    return this.dependencies ? Object.keys(this.dependencies).sort() : []
   }
 
   get devDepNames () {
-    return this.devDependencies ? Object.keys(this.devDependencies) : []
+    return this.devDependencies ? Object.keys(this.devDependencies).sort() : []
+  }
+
+  get allDepNames () {
+    return this.depNames.concat(this.devDepNames).sort()
   }
 
   get valid () {

--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ module.exports = class Package {
     return this.devDepNames.indexOf(dep) > -1
   }
 
-  dependsSomehowOn (dep) {
+  somehowDependsOn (dep) {
     return this.dependsOn(dep) || this.devDependsOn(dep)
   }
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Clean up messy package metadata from the npm registry",
   "main": "index.js",
   "scripts": {
-    "test": "node tests/index.js | tap-spec && standard"
+    "test": "node tests/index.js | tap-spec && standard && standard-markdown"
   },
   "repository": "https://github.com/zeke/nice-package",
   "keywords": [
@@ -26,6 +26,7 @@
   "devDependencies": {
     "require-dir": "^0.3.0",
     "standard": "^7.1.2",
+    "standard-markdown": "^1.2.1",
     "tap-spec": "^4.1.1",
     "tape": "^4.6.0"
   },

--- a/tests/index.js
+++ b/tests/index.js
@@ -40,8 +40,14 @@ test('Package', function (t) {
   t.notOk(pkg.dependsOn('monkeys'), 'dependsOn')
   t.ok(pkg.devDependsOn('istanbul'), 'devDependsOn')
 
+  t.ok(pkg.dependsSomehowOn('finalhandler'), 'dependsSomehowOn includes deps')
+  t.ok(pkg.dependsSomehowOn('istanbul'), 'dependsSomehowOn includes devDeps')
+
   t.ok(pkg.depNames.indexOf('finalhandler') > -1, 'depNames')
   t.ok(pkg.devDepNames.indexOf('istanbul') > -1, 'devDepNames')
+
+  t.ok(pkg.allDepNames.indexOf('finalhandler') > -1, 'allDepNames includes depNames')
+  t.ok(pkg.allDepNames.indexOf('istanbul') > -1, 'allDepNames includes devDepNames')
 
   t.ok(pkg.mentions('minimalist web framework'), '`mentions` looks for a string anywhere in the object')
   t.ok(pkg.mentions('MINIMALIST WEB FRAMEWORK'), '`mentions` is case insensitive')

--- a/tests/index.js
+++ b/tests/index.js
@@ -40,8 +40,8 @@ test('Package', function (t) {
   t.notOk(pkg.dependsOn('monkeys'), 'dependsOn')
   t.ok(pkg.devDependsOn('istanbul'), 'devDependsOn')
 
-  t.ok(pkg.dependsSomehowOn('finalhandler'), 'dependsSomehowOn includes deps')
-  t.ok(pkg.dependsSomehowOn('istanbul'), 'dependsSomehowOn includes devDeps')
+  t.ok(pkg.somehowDependsOn('finalhandler'), 'somehowDependsOn includes deps')
+  t.ok(pkg.somehowDependsOn('istanbul'), 'somehowDependsOn includes devDeps')
 
   t.ok(pkg.depNames.indexOf('finalhandler') > -1, 'depNames')
   t.ok(pkg.devDepNames.indexOf('istanbul') > -1, 'devDepNames')


### PR DESCRIPTION
`pkg.allDepNames` returns all names in `dependencies` and `devDependenices`

`pkg.dependsSomehowOn('lodash')` looks in `dependencies` and `devDependenices`
