### PR TITLE
preserve non-github repository data

### DIFF
--- a/lib/clean.js
+++ b/lib/clean.js
@@ -21,11 +21,14 @@ module.exports = function clean (doc) {
     return doc
   }
 
+  var repo
   try {
-    pkg.repository = gh(pkg.repository.url)
+    repo = gh(pkg.repository.url)
   } catch (e) {
     // no worries
   }
+
+  if (repo) pkg.repository = repo
 
   if (doc.users) {
     pkg.stars = Object.keys(doc.users).length

--- a/tests/fixtures/bitbucket.json
+++ b/tests/fixtures/bitbucket.json
@@ -1,0 +1,9 @@
+{
+  "name": "bitty-buck",
+  "version": "1.0.0",
+  "description": "my repo URL is not on GitHub and that's okay",
+  "repository": {
+    "type": "git",
+    "url": "https://bitbucket.org/monkey/business.git"
+  }
+}

--- a/tests/index.js
+++ b/tests/index.js
@@ -82,5 +82,11 @@ test('Package', function (t) {
   t.notOk(sparsePackage.name, 'does not have a name')
   t.notOk(sparsePackage.valid, 'is not valid')
   t.ok(sparsePackage.dependsOn('request'), 'still has working convenience methods')
+
+  t.comment('non-GitHub repository URLs')
+  var bitty = new Package(fixtures.bitbucket)
+  t.equal(bitty.repository.type, 'git', 'retains type value')
+  t.equal(bitty.repository.url, 'https://bitbucket.org/monkey/business.git', 'retains url value')
+
   t.end()
 })


### PR DESCRIPTION
Fixes https://github.com/zeke/nice-package/issues/10, which was an accident. Not an intentional dismissal of non-github URLs!
