### PR TITLE
sanitize packages with a valid property

### DIFF
--- a/lib/clean.js
+++ b/lib/clean.js
@@ -18,6 +18,7 @@ module.exports = function clean (doc) {
     pkg = doc
   } else {
     // incomplete package.json object
+    if (doc && typeof doc.valid !== 'undefined') delete doc.valid
     return doc
   }
 
@@ -75,6 +76,7 @@ module.exports = function clean (doc) {
   delete pkg._shasum
   delete pkg._from
   delete pkg.npmVersion
+  delete pkg.valid
 
   return pkg
 }

--- a/tests/fixtures/disallowed-valid-property.json
+++ b/tests/fixtures/disallowed-valid-property.json
@@ -1,0 +1,5 @@
+{
+  "name": "disallowed-valid-property",
+  "description": "a package that has a property named `valid` in its package.json",
+  "valid": false
+}

--- a/tests/index.js
+++ b/tests/index.js
@@ -88,5 +88,9 @@ test('Package', function (t) {
   t.equal(bitty.repository.type, 'git', 'retains type value')
   t.equal(bitty.repository.url, 'https://bitbucket.org/monkey/business.git', 'retains url value')
 
+  t.comment('packages with `valid` property')
+  var val = new Package(fixtures['disallowed-valid-property'])
+  t.ok(val.valid, 'it ignores the provided property in favor of internal getter')
+
   t.end()
 })


### PR DESCRIPTION
Was getting this bug for packages that have a `valid` property set in their package.json:

```
/Users/zeke/zeke/package-stream/node_modules/nice-package/index.js:10
    Object.assign(this, pkg)
           ^

TypeError: Cannot set property valid of #<Package> which has only a getter
    at new Package (/Users/zeke/zeke/package-stream/node_modules/nice-package/index.js:10:12)
    at ChangesStream.<anonymous> (/Users/zeke/zeke/package-stream/index.js:25:17)
    at emitOne (events.js:96:13)
    at ChangesStream.emit (events.js:188:7)
    at ChangesStream.<anonymous> (/Users/zeke/zeke/package-stream/node_modules/readable-stream/lib/_stream_readable.js:786:14)
    at emitNone (events.js:86:13)
    at ChangesStream.emit (events.js:185:7)
    at emitReadable_ (/Users/zeke/zeke/package-stream/node_modules/readable-stream/lib/_stream_readable.js:448:10)
    at emitReadable (/Users/zeke/zeke/package-stream/node_modules/readable-stream/lib/_stream_readable.js:444:5)
    at readableAddChunk (/Users/zeke/zeke/package-stream/node_modules/readable-stream/lib/_stream_readable.js:187:9)
```
