### PR TITLE
format github repositories as https URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ package cleanup:
 - turns the `time` object into an array of version data
 - renames `_npmUser` to `lastPublisher`
 - renames `maintainers` to `owners`
-- parses GitHUB repository URLs into [useful objects](https://github.com/zeke/github-url-to-object#readme)
+- normalizes GitHub repository URLs to `https` format
 - removes internal bookkeeping properties like `_id` and `_from`
 - [more...](tests/index.js)
 

--- a/lib/clean.js
+++ b/lib/clean.js
@@ -28,9 +28,10 @@ module.exports = function clean (doc) {
 
   var repo
   try {
-    repo = gh(pkg.repository.url)
+    // attempt to sanitize github repo to a plain HTTPS url
+    repo = gh(pkg.repository.url).https_url
   } catch (e) {
-    // no worries
+    // not a github repo; no worries
   }
 
   if (repo) pkg.repository = repo

--- a/tests/index.js
+++ b/tests/index.js
@@ -83,6 +83,10 @@ test('Package', function (t) {
   t.notOk(sparsePackage.valid, 'is not valid')
   t.ok(sparsePackage.dependsOn('request'), 'still has working convenience methods')
 
+  t.comment('GitHub repository URL')
+  var gitty = new Package(fixtures.express)
+  t.equal(gitty.repository, 'https://github.com/expressjs/express', `is an HTTPS URL ${gitty.repository}`)
+
   t.comment('non-GitHub repository URLs')
   var bitty = new Package(fixtures.bitbucket)
   t.equal(bitty.repository.type, 'git', 'retains type value')


### PR DESCRIPTION
The current version is turning GitHub-based repository URLs into objects using [github-url-to-object](https://github.com/zeke/github-url-to-object). It seemed like it would be convenient, but it's actually just annoying. I really only ever end up wanting the plain old https repo URL.

And so, this PR exists. This is a breaking change, hence a bump to 2.0.0