### PR TITLE
top-level props override latest-version props

### DIFF
--- a/lib/clean.js
+++ b/lib/clean.js
@@ -16,8 +16,8 @@ module.exports = function clean (doc) {
   if (latest) {
     // this is a registry object
     doc = normalize(doc)
-    // overwrite top-level props with metadata from the last released version
-    pkg = Object.assign({}, doc, doc.versions[latest])
+    // add props from lastest release that are absent from the top level
+    pkg = Object.assign({}, doc.versions[latest], doc)
   } else if (doc.name && doc.description) {
     // this is a basic object, i.e. a package.json file
     pkg = doc


### PR DESCRIPTION
A subtle change.. This will prevent any modified top-level props from being overwritten when merging in props from the latest release object.