### PR TITLE
update github-url-to-object to avoid DoS vuln 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "standard-markdown": "^1.2.1"
   },
   "dependencies": {
-    "github-url-to-object": "^2.2.1",
+    "github-url-to-object": "^4.0.4",
     "lodash": "^4.17.2",
     "normalize-registry-metadata": "^1.1.2",
     "revalidator": "^0.3.1",


### PR DESCRIPTION
Hello!

  Love the package! Recently SNYK issued a vulnerability report issued for a dependency, "github-url-to-object" (https://snyk.io/vuln/npm:github-url-to-object:20180226). That issue has been fixed in github-url-to-object version 4.

  I've gone ahead and updated the dependency (all tests pass), and added `node_modules` to a .gitignore just for publishing sanity.

  Let me know if I can do anything else to help!!
